### PR TITLE
i18n

### DIFF
--- a/messages/de.json
+++ b/messages/de.json
@@ -1,0 +1,5 @@
+{
+    "Index": {
+        "title": "Hallo Welt!"
+    }
+}

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,26 +1,24 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
-import "../globals.css"
+import "../globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
-  title: "Website example",
-  description: "Description of the website",
+    title: "Website example",
+    description: "Description of the website",
 };
 
 export default function LocaleLayout({
     children,
-    params: {locale}
-  }: {
+    params: { locale },
+}: {
     children: React.ReactNode;
-    params: {locale: string};
-  }) {
+    params: { locale: string };
+}) {
     return (
-      <html lang={locale}>
-        <body>
-          {children}
-        </body>
-      </html>
+        <html className={inter.className} lang={locale}>
+            <body>{children}</body>
+        </html>
     );
-  }
+}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -1,13 +1,12 @@
-
 import { Homepage } from "@/components/homepage";
 import { useTranslations } from "next-intl";
 
 export default function Index() {
-  const t = useTranslations("Index");
-  return (
-    <>
-      {/* <h1>{t('title')}</h1> */}
-      <Homepage />
-    </>
-  );
+    const t = useTranslations("Index");
+    return (
+        <>
+            <h1>{t("title")}</h1>
+            <Homepage />
+        </>
+    );
 }

--- a/src/app/[locale]/test/test2/page.tsx
+++ b/src/app/[locale]/test/test2/page.tsx
@@ -6,7 +6,7 @@ const Page = () => {
     return (
         <>
             <h1>{t("title")}</h1>
-            test page
+            <p>test2</p>
         </>
     );
 };

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,14 +1,12 @@
-import {notFound} from 'next/navigation';
-import {getRequestConfig} from 'next-intl/server';
- 
-// Can be imported from a shared config
-const locales = ['en', 'es'];
- 
-export default getRequestConfig(async ({locale}) => {
-  // Validate that the incoming `locale` parameter is valid
-  if (!locales.includes(locale as any)) notFound();
- 
-  return {
-    messages: (await import(`../messages/${locale}.json`)).default
-  };
+import { notFound } from "next/navigation";
+import { getRequestConfig } from "next-intl/server";
+import { locales } from "./navigation";
+
+export default getRequestConfig(async ({ locale }) => {
+    // Validate that the incoming `locale` parameter is valid
+    if (!locales.includes(locale as any)) notFound();
+
+    return {
+        messages: (await import(`../messages/${locale}.json`)).default,
+    };
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,14 +1,14 @@
-import createMiddleware from 'next-intl/middleware';
- 
+import createMiddleware from "next-intl/middleware";
+
 export default createMiddleware({
-  // A list of all locales that are supported
-  locales: ['es', 'en'],
-  // Used when no locale matches
-  defaultLocale: 'en',
-  localePrefix: 'as-needed'
+    // A list of all locales that are supported
+    locales: ["es", "en"],
+    // Used when no locale matches
+    defaultLocale: "en",
+    localePrefix: "as-needed",
 });
- 
+
 export const config = {
-  // Match only internationalized pathnames
-  matcher: ['/', '/(en|es)/:path*']
+    // Match only internationalized pathnames
+    matcher: ["/", "/((?!api|_next|_vercel|.*\\..*).*)", "/([\\w-]+)?//(.+)"],
 };

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,14 +1,14 @@
 import createMiddleware from "next-intl/middleware";
+import { locales, localePrefix } from "./navigation";
 
 export default createMiddleware({
     // A list of all locales that are supported
-    locales: ["es", "en"],
+    locales,
     // Used when no locale matches
     defaultLocale: "en",
-    localePrefix: "as-needed",
+    localePrefix,
 });
 
 export const config = {
-    // Match only internationalized pathnames
     matcher: ["/", "/((?!api|_next|_vercel|.*\\..*).*)", "/([\\w-]+)?//(.+)"],
 };

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,6 +1,6 @@
 import { createSharedPathnamesNavigation } from "next-intl/navigation";
 
-export const locales = ["es", "en"] as const;
+export const locales = ["es", "en", "de"] as const;
 export const localePrefix = "as-needed";
 
 export const { Link, redirect, usePathname, useRouter } =

--- a/src/navigation.ts
+++ b/src/navigation.ts
@@ -1,0 +1,7 @@
+import { createSharedPathnamesNavigation } from "next-intl/navigation";
+
+export const locales = ["es", "en"] as const;
+export const localePrefix = "as-needed";
+
+export const { Link, redirect, usePathname, useRouter } =
+    createSharedPathnamesNavigation({ locales, localePrefix });


### PR DESCRIPTION
# Redirection Problem

the problem was that `next-intl` was configured to emit the locale name if the user language is the default(English), but the middleware which is responsible of redirecting the user to correct locale was not configured for such case

## Add new langs

to make it easy to add support for new lang,i grouped all the configuration in one place `src/navigation.ts`. 

you can see example how to add new lang in the last commit TODO: add commit hash

here's the steps to add support for german:

1. in `src/navigation.ts` edit `locales` with the new language you want to support in out case the shortcut for German is `de`
```ts
//                                 ^^^^^
export const locales = ["es", "en", "de"] as const;
```

2. add the new translation in `messages` in our case will create the file `messages/de.json`
```ts
// file content
{
    "Index": {
        "title": "Hallo Welt!"
    }
}
```

3. that's it visit any path and see the german translation for example visit `http://localhost:3000/de/test`

in the same file i added `next-intl` aware navigation helpers like `Link, redirect, usePathname, useRouter` you can check the documentation for this part here [https://next-intl-docs.vercel.app/docs/routing/navigation](https://next-intl-docs.vercel.app/docs/routing/navigation) , those are just small wrappers around the default nextjs implementation to make navigation with different locales easier

if you have any question please let me know
